### PR TITLE
Simply the form so that we always show themes.

### DIFF
--- a/back-to-the-theme.css
+++ b/back-to-the-theme.css
@@ -18,3 +18,20 @@
 	resize: both;
 	width: 100%;
 }
+
+.back-to-the-theme-preview-info {
+	position: sticky;
+	top: 28px;
+	padding: 16px;
+	background: #FFF;
+	max-height: 20px;
+	overflow: hidden;
+	display: flex;
+	justify-content: space-between;
+}
+
+.back-to-the-theme-preview-info .spinner {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+}

--- a/class.back-to-the-theme.php
+++ b/class.back-to-the-theme.php
@@ -74,16 +74,14 @@ class BackToTheTheme {
 		return $theme ? $theme->stylesheet : $stylesheet;
 	}
 
-	public static function get_preview_url( $theme, $id, $secret, $hide_admin_bar = true, $side ) {
-		$query_args = array(
-			'back-to-the-theme-secret' => $secret,
-			'back-to-the-theme' => $theme,
-			'flux-capacitor-cache-buster' => time(),
-		);
+	public static function get_preview_url( $theme, $id, $secret, $side ) {
 
-		if ( $hide_admin_bar ) {
-			$query_args['back-to-the-theme-hide-admin-bar'] = true;
-		}
+		$query_args = array(
+			'back-to-the-theme-secret' 			=> $secret,
+			'back-to-the-theme' 				=> $theme,
+			'flux-capacitor-cache-buster' 		=> time(),
+			'back-to-the-theme-hide-admin-bar'  => true,
+		);
 
 		if ( empty( $id ) ) {
 			$url = home_url();
@@ -132,7 +130,7 @@ class BackToTheTheme {
 				$secret = self::update_secret();
 				$side = self::get_side();
 
-				$hide_admin_bar = true;
+
 				$id = isset( $_GET['back-to-the-theme-post-id'] ) && intval( $_GET['back-to-the-theme-post-id'] )
 					? intval( $_GET['back-to-the-theme-post-id'] )
 					: absint( $_GET['page_id'] );
@@ -145,7 +143,7 @@ class BackToTheTheme {
 						continue;
 					}
 
-					$url = self::get_preview_url( $theme, $id, $secret, $hide_admin_bar, $side );
+					$url = self::get_preview_url( $theme, $id, $secret, $side );
 					$theme_name = $themes[ $theme ]->get( 'Name' );
 					$theme_version = $themes[ $theme ]->get( 'Version' );
 


### PR DESCRIPTION
This PR Updates the UI so that we always just shows all the themes. 
I move the form from POST to GET so that a refresh of the page works nicely. 

I removed the theme picker. The page still loads fast since we are lazy loading the themes. 

I also added a sticky header so that you can see the theme that you are looking at. 
I added loader so that you know that the iframe is loading. I think it would be good to add some sort of js loading of the iframe instead of the lazy loading approach mostly so you can skip to different parts. 